### PR TITLE
Make endfire cart recipe conditional on Endergetic being loaded

### DIFF
--- a/src/main/resources/data/moreminecarts/recipes/endfire_cart.json
+++ b/src/main/resources/data/moreminecarts/recipes/endfire_cart.json
@@ -18,5 +18,11 @@
   },
   "result": {
     "item": "moreminecarts:endfire_cart"
-  }
+  },
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "endergetic"
+    }
+  ]
 }


### PR DESCRIPTION
This prevents the following error when Endergetic Expansion is not loaded: `[WARN] Failed to parse recipe moreminecarts:endfire_cart[minecraft:crafting_shaped]: com.google.gson.JsonSyntaxException: Unknown item 'endergetic:ender_campfire'`