### PR TITLE
Fixed unloading into an empty slot ignoring the leave one in stack setting.

### DIFF
--- a/src/main/java/com/alc/moreminecarts/tile_entities/MinecartUnloaderTile.java
+++ b/src/main/java/com/alc/moreminecarts/tile_entities/MinecartUnloaderTile.java
@@ -200,8 +200,9 @@ public class MinecartUnloaderTile extends AbstractCommonLoader implements ITicka
                 boolean did_load = false;
 
                 if (add_to_stack.isEmpty()) {
+                    int true_count = stack.getCount() - (leave_one_in_stack? 1 : 0);
                     ItemStack new_stack = stack.copy();
-                    int transfer_amount = Math.min(8, new_stack.getCount());
+                    int transfer_amount = Math.min(8, true_count);
                     new_stack.setCount(transfer_amount);
                     this.setItem(j, new_stack);
                     stack.shrink(transfer_amount);


### PR DESCRIPTION
Title describes it, if there is more than one item in a slot, all items are removed, if there is no item in the output.