### PR TITLE
Prevent client keybind register event from firing on server after Forge update to 41.0.98

### DIFF
--- a/src/main/java/com/alc/moreminecarts/proxy/ClientProxy.java
+++ b/src/main/java/com/alc/moreminecarts/proxy/ClientProxy.java
@@ -7,11 +7,12 @@ import com.alc.moreminecarts.client.PistonPushcartUpKey;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-@Mod.EventBusSubscriber(modid =  MMConstants.modid, bus = Mod.EventBusSubscriber.Bus.FORGE)
+@Mod.EventBusSubscriber(modid =  MMConstants.modid, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class ClientProxy implements IProxy {
 
     @Override


### PR DESCRIPTION
Fixes an issue with keybind event firing on servers, introduced in pull #71.

Tested on dedicated server and client.