### PR TITLE
[1.19] Fix pushcart keybinds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 # are changed when only line endings change.
 src/generated/**/.cache/cache text eol=lf
 src/generated/**/*.json text eol=lf
+
+# So linux users don't need to run dos2unix 
+gradlew text eol=lf

--- a/src/main/java/com/alc/moreminecarts/client/ModKeyMappings.java
+++ b/src/main/java/com/alc/moreminecarts/client/ModKeyMappings.java
@@ -1,0 +1,24 @@
+package com.alc.moreminecarts.client;
+
+import com.alc.moreminecarts.MMConstants;
+import net.minecraft.client.KeyMapping;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = MMConstants.modid, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class ModKeyMappings {
+
+	// Jump key
+	public static final KeyMapping PISTON_PUSHCART_UP = new PistonPushcartUpKey("Piston Pushcart Up", 32, "More Minecarts and Rails");
+
+	// Left control key
+	public static final KeyMapping PISTON_PUSHCART_DOWN = new PistonPushcartDownKey("Piston Pushcart Down", 341, "More Minecarts and Rails");
+
+	@SubscribeEvent
+	public void setupKeybindings(RegisterKeyMappingsEvent event) {
+		event.register(PISTON_PUSHCART_UP);
+		event.register(PISTON_PUSHCART_DOWN);
+	}
+}

--- a/src/main/java/com/alc/moreminecarts/client/PistonPushcartDownKey.java
+++ b/src/main/java/com/alc/moreminecarts/client/PistonPushcartDownKey.java
@@ -12,7 +12,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 @OnlyIn(Dist.CLIENT)
 public class PistonPushcartDownKey extends KeyMapping {
 
-
     public PistonPushcartDownKey(String description, int default_key, String category) {
         super(description, default_key, category);
     }

--- a/src/main/java/com/alc/moreminecarts/proxy/ClientProxy.java
+++ b/src/main/java/com/alc/moreminecarts/proxy/ClientProxy.java
@@ -12,7 +12,7 @@ import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-@Mod.EventBusSubscriber(modid =  MMConstants.modid, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
+@Mod.EventBusSubscriber(modid =  MMConstants.modid, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class ClientProxy implements IProxy {
 
     @Override
@@ -34,14 +34,4 @@ public class ClientProxy implements IProxy {
     public boolean isHoldingRun() {
         return Minecraft.getInstance().player.input.shiftKeyDown;
     }
-
-    @SubscribeEvent
-    public void setupKeybindings(RegisterKeyMappingsEvent event) {
-        // Jump key
-        event.register(new PistonPushcartUpKey("Piston Pushcart Up", 32, "More Minecarts and Rails"));
-        // Left control key
-        event.register(new PistonPushcartDownKey("Piston Pushcart Down", 341, "More Minecarts and Rails"));
-    }
-
-
 }

--- a/src/main/java/com/alc/moreminecarts/proxy/ClientProxy.java
+++ b/src/main/java/com/alc/moreminecarts/proxy/ClientProxy.java
@@ -1,18 +1,9 @@
 package com.alc.moreminecarts.proxy;
 
-import com.alc.moreminecarts.MMConstants;
-import com.alc.moreminecarts.MoreMinecartsMod;
-import com.alc.moreminecarts.client.PistonPushcartDownKey;
-import com.alc.moreminecarts.client.PistonPushcartUpKey;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 
-@Mod.EventBusSubscriber(modid =  MMConstants.modid, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class ClientProxy implements IProxy {
 
     @Override


### PR DESCRIPTION
Fixes pushcart keybinds after I broke them in #71 and #72.

Tested the push cart in dev environment. Can be extended and retracted with Space and Left Ctrl.