### PR TITLE
Add missing lang entries for potted plants

### DIFF
--- a/src/main/resources/assets/moreminecarts/lang/en_us.json
+++ b/src/main/resources/assets/moreminecarts/lang/en_us.json
@@ -43,6 +43,8 @@
   "block.moreminecarts.chunkrodite_block": "Chunkrodite Block",
   "block.moreminecarts.glass_cactus": "Vitric Cactus",
   "block.moreminecarts.holo_scaffold_generator": "Holo-Scaffold Generator",
+  "block.moreminecarts.potted_glass_cactus": "Potted Vitric Cactus",
+  "block.moreminecarts.potted_beet": "Potted Beet",
 
   "block.moreminecarts.color_detector_rail_white": "Color Detector Rail (White)",
   "block.moreminecarts.color_detector_rail_orange": "Color Detector Rail (Orange)",


### PR DESCRIPTION
This PR adds localized names for the potted vitric cactus & potted beet. The use for these translations in vanilla is almost nonexistent, but mods can still get them using Block::getName (All vanilla blocks have translations even if they don't have a corresponding item)